### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NeuroSwipe
+# Neural glide typing
 
 A transformer neural network for a gesture keyboard that transduces curves swiped across a keyboard into word candidates
 

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,25 +1,29 @@
 from typing import Collection, List
+from warnings import warn
 
 import torch
 from aggregate_predictions import delete_duplicates_stable
 
 def get_mmr(preds_list: Collection[Collection[str]], ref: Collection[str]) -> float:
     # Works properly if has duplicates or n_line_preds < 4
+    if len(preds_list) != len(ref):
+        warn("Prediction and target lengths not equal: " \
+             f"`len(preds_list)` = {len(preds_list)}, `len(ref)` = {len(ref)}")
 
-    MRR = 0
+    mrr = 0
     
     for preds, target in zip(preds_list, ref):
         preds = delete_duplicates_stable(preds)
         weights = [1, 0.1, 0.09, 0.08]
 
-        line_MRR = sum(weight * (pred == target)
+        line_mrr = sum(weight * (pred == target)
                        for weight, pred in zip(weights, preds))
 
-        MRR += line_MRR
+        mrr += line_mrr
     
-    MRR /= len(preds_list)
+    mrr /= len(ref)
 
-    return MRR
+    return mrr
 
 
 def get_accuracy(preds_list: List[str], ref: List[str]) -> float:

--- a/src/model.py
+++ b/src/model.py
@@ -423,8 +423,7 @@ def get_word_char_embedding_model_bigger__v3(d_model: int, n_word_chars: int,
 
 
 def _get_transformer_bigger__v3(input_embedding: nn.Module,
-                                device = None,
-                                n_coord_feats = 6):
+                                device = None,):
     CHAR_VOCAB_SIZE = 37  # = len(word_char_tokenizer.char_to_idx)
     MAX_OUT_SEQ_LEN = 35  # word_char_tokenizer.max_word_len - 1
 
@@ -434,9 +433,7 @@ def _get_transformer_bigger__v3(input_embedding: nn.Module,
     n_classes = CHAR_VOCAB_SIZE - 2  # <sos> and <pad> are not predicted
 
 
-    key_emb_size = 122
-    n_coord_feats = 6
-    d_model = n_coord_feats + key_emb_size
+    d_model = 128
 
     device = torch.device(
         device
@@ -491,7 +488,7 @@ def get_transformer_bigger_weighted_and_traj__v3(device = None,
         n_keys=n_keys, key_emb_size=key_emb_size, 
         max_len=MAX_CURVES_SEQ_LEN, device = device, dropout=0.1)
     
-    model = _get_transformer_bigger__v3(input_embedding, device, n_coord_feats)
+    model = _get_transformer_bigger__v3(input_embedding, device)
 
     model = _set_state(model, weights_path, device)
 
@@ -514,7 +511,7 @@ def get_transformer_bigger_nearest_and_traj__v3(device = None,
         n_keys=37, key_emb_size=key_emb_size, 
         max_len=299, device = device, dropout=0.1)
     
-    model = _get_transformer_bigger__v3(input_embedding, device, n_coord_feats)
+    model = _get_transformer_bigger__v3(input_embedding, device)
 
     model = _set_state(model, weights_path, device)
 
@@ -563,7 +560,7 @@ def get_transformer_bigger_trainable_gaussian_weights_and_traj__v3(
         max_len=299, device=device, dropout=0.1,
         key_centers=key_centers)
     
-    model = _get_transformer_bigger__v3(input_embedding, device, n_coord_feats)
+    model = _get_transformer_bigger__v3(input_embedding, device)
 
     model = _set_state(model, weights_path, device)
 

--- a/src/word_generation_demo.ipynb
+++ b/src/word_generation_demo.ipynb
@@ -12,39 +12,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "from multiprocessing import cpu_count\n",
-    "from typing import List, Iterable, Set, Optional, Dict, Tuple\n",
+    "from typing import List, Tuple, Callable\n",
     "\n",
     "import torch\n",
-    "import torch.nn as nn\n",
-    "from tqdm import tqdm\n",
     "import numpy as np\n",
     "\n",
     "# from model import get_m1_model, get_m1_bigger_model, get_m1_smaller_model\n",
     "from model import MODEL_GETTERS_DICT\n",
     "from ns_tokenizers import CharLevelTokenizerv2, KeyboardTokenizerv1\n",
-    "from ns_tokenizers import ALL_CYRILLIC_LETTERS_ALPHABET_ORD\n",
     "from dataset import CurveDataset, CurveDatasetSubset\n",
     "from word_generators_v2 import GreedyGenerator, BeamGenerator, WordGenerator\n",
-    "from predict_v2 import Predictor\n",
     "from metrics import get_mmr\n",
-    "from aggregate_predictions import (separate_out_vocab_all_crvs,\n",
-    "                                   append_preds,\n",
-    "                                   create_submission,\n",
-    "                                   merge_default_and_extra_preds)\n",
     "from feature_extractors import weights_function_v1\n",
-    "from feature_extractors import get_val_transform\n",
-    "from grid_processing_utils import get_grid"
+    "from feature_extractors import get_val_transform"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,12 +58,12 @@
     "TEST_PATH = os.path.join(DATA_ROOT, \"test.jsonl\")\n",
     "\n",
     "VOCAB_PATH = os.path.join(DATA_ROOT, \"voc.txt\")\n",
-    "G_NAME_TO_GRID_PATH = os.path.join(DATA_ROOT, \"gridname_to_grid.json\")"
+    "GRID_NAME_TO_GRID_PATH = os.path.join(DATA_ROOT, \"gridname_to_grid.json\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -84,32 +74,12 @@
      ]
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63a8338f3aa7485c81d6cf13f47dee72",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/10000 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eceb66598a41489b9a586efdc2ce6a3a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/10000 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [00:00<00:00, 19812.25it/s]\n",
+      "100%|██████████| 10000/10000 [00:00<00:00, 20734.91it/s]\n"
+     ]
     },
     {
      "name": "stdout",
@@ -123,16 +93,13 @@
     "kb_tokenizer = KeyboardTokenizerv1()\n",
     "char_tokenizer = CharLevelTokenizerv2(VOCAB_PATH)\n",
     "\n",
-    "data_paths = [\n",
-    "    VAL_PATH,\n",
-    "    TEST_PATH\n",
-    "]\n",
+    "data_paths = [VAL_PATH, TEST_PATH]\n",
     "\n",
     "# takes almost no time\n",
     "dist_transform_v1 = get_val_transform(\n",
-    "    gridname_to_grid_path=G_NAME_TO_GRID_PATH,\n",
+    "    gridname_to_grid_path=GRID_NAME_TO_GRID_PATH,\n",
     "    grid_names=('default', 'extra'),\n",
-    "    transform_name=\"traj_feats_and_distances\",\n",
+    "    transform_name=\"traj_feats_and_distance_weights\",\n",
     "    char_tokenizer=char_tokenizer,\n",
     "    dist_weights_func=weights_function_v1,\n",
     "    include_time=False,\n",
@@ -142,7 +109,7 @@
     "\n",
     "# takes a lot of time\n",
     "kb_transform = get_val_transform(\n",
-    "    gridname_to_grid_path=G_NAME_TO_GRID_PATH,\n",
+    "    gridname_to_grid_path=GRID_NAME_TO_GRID_PATH,\n",
     "    grid_names=('default', 'extra'),\n",
     "    transform_name=\"traj_feats_and_nearest_key\",\n",
     "    char_tokenizer=char_tokenizer,\n",
@@ -157,15 +124,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "10000it [00:00, 11101.07it/s]\n",
-      "10000it [00:00, 13174.88it/s]\n"
+      "0it [00:00, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "10000it [00:00, 21783.35it/s]\n",
+      "10000it [00:00, 21957.25it/s]\n"
      ]
     }
    ],
@@ -189,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,16 +220,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "dict_keys(['m1', 'm1_bigger', 'm1_smaller', 'transformer_m1_bigger', 'transformer_bb_model', 'weighted_transformer_bigger', 'v2_weighted_transformer_bigger', 'v2_nearest_transformer_bigger', 'v3_weighted_and_traj_transformer_bigger', 'v3_nearest_and_traj_transformer_bigger', 'v3_nearest_only_transformer_bigger', 'v3_trainable_gaussian_weights_and_traj_transformer_bigger'])"
+       "dict_keys(['v3_weighted_and_traj_transformer_bigger', 'v3_nearest_and_traj_transformer_bigger', 'v3_nearest_only_transformer_bigger', 'v3_trainable_gaussian_weights_and_traj_transformer_bigger', 'm1', 'm1_bigger', 'm1_smaller'])"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,24 +240,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val_default_targets = get_targets(val_default_dataset, char_tokenizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "grid_name = \"default\"\n",
     "model_getter = MODEL_GETTERS_DICT['v3_weighted_and_traj_transformer_bigger']\n",
-    "weights_path = r\"..\\results\\models_for_debug\\weighted_transformer_bigger-default--epoch=60-val_loss=0.442-val_word_level_accuracy=0.875.pt\"\n",
+    "weights_path = r\"../results/models_for_debug/weighted_transformer_bigger-default--epoch=60-val_loss=0.442-val_word_level_accuracy=0.875.pt\"\n",
     "\n",
     "# model_getter = MODEL_GETTERS_DICT['v3_nearest_and_traj_transformer_bigger']\n",
     "# weights_path = r\"..\\results\\models_for_debug\\my_features_1\\v3_nearest_and_traj_transformer_bigger-default--epoch=32-val_loss=0.441-val_word_level_accuracy=0.864.pt\"\n",
     "\n",
-    "model = model_getter(device, weights_path)\n",
+    "model = model_getter(device, weights_path).eval()\n",
     "grid_name_to_greedy_generator = {grid_name: GreedyGenerator(model, char_tokenizer, device)}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,12 +306,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Callable\n",
-    "\n",
     "MAX_WORD_LEN = 35\n",
     "\n",
     "def predict(word_generator: WordGenerator, dataset, n_hypotheses, scores_to_prob: Callable, \n",
@@ -346,6 +327,8 @@
     "        print(\"-\"*(15+30*n_hypotheses))\n",
     "\n",
     "    for i, data in enumerate(val_default_dataset):\n",
+    "        if i >= n_examples:\n",
+    "            return curve_id_to_hypotheses\n",
     "\n",
     "        (encoder_in, dec_in), target = data\n",
     "\n",
@@ -362,16 +345,32 @@
     "        flat_preds_and_scores = (item for pair in preds_and_probs_full[:n_hypotheses] for item in pair)\n",
     "        if verbose:\n",
     "            print((\"{:<15}   |   \" + \"{:<16}{:.4f}   |   \" *n_hypotheses ).format(true_label, *flat_preds_and_scores))\n",
-    "\n",
-    "        if i >= n_examples:\n",
-    "            return curve_id_to_hypotheses\n",
     "    \n",
     "    return curve_id_to_hypotheses"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remove_scores_from_results(swipe_id_to_hypotheses_lst: list) -> list:\n",
+    "    return [[pred for pred, score in item_hypothses_lst] for item_hypothses_lst in swipe_id_to_hypotheses_lst]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_EXAMPLES = 40"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -395,19 +394,65 @@
       "она               |   она             0.9011   |   \n",
       "проблема          |   проблема        0.8468   |   \n",
       "билайн            |   билайн          0.8468   |   \n",
-      "уже               |   уже             0.9064   |   \n"
+      "уже               |   уже             0.9064   |   \n",
+      "раньше            |   раньше          0.8657   |   \n",
+      "рам               |   нам             0.7396   |   \n",
+      "щас               |   щас             0.9419   |   \n",
+      "купил             |   купил           0.7817   |   \n",
+      "ты                |   ты              0.9104   |   \n",
+      "зовут             |   зовут           0.8996   |   \n",
+      "короче            |   короче          0.8362   |   \n",
+      "размыто           |   размыто         0.2740   |   \n",
+      "давай             |   давай           0.8700   |   \n",
+      "отдать            |   отдать          0.5606   |   \n",
+      "привет            |   привет          0.8450   |   \n",
+      "не                |   не              0.8842   |   \n",
+      "да                |   да              0.8947   |   \n",
+      "будете            |   будете          0.8685   |   \n",
+      "связи             |   связи           0.8859   |   \n",
+      "колывань          |   колывани        0.5530   |   \n",
+      "меня              |   меня            0.8577   |   \n",
+      "напиши            |   напиши          0.8690   |   \n",
+      "знаю              |   знаю            0.9134   |   \n",
+      "мамой             |   мамой           0.8660   |   \n",
+      "не                |   не              0.8892   |   \n",
+      "ты                |   ты              0.9095   |   \n",
+      "только            |   только          0.8676   |   \n",
+      "они               |   они             0.8998   |   \n"
      ]
     }
    ],
    "source": [
     "curve_id_to_hypotheses = predict(\n",
     "    greedy_generator_with_vocab, val_dataset, n_hypotheses=1, \n",
-    "    scores_to_prob=lambda pred, score: np.exp(-score), n_examples=15)"
+    "    scores_to_prob=lambda pred, score: np.exp(-score), n_examples=N_EXAMPLES)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.925"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_mmr(\n",
+    "    remove_scores_from_results(curve_id_to_hypotheses), \n",
+    "    val_default_targets[:N_EXAMPLES])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -431,19 +476,65 @@
       "она               |   она             0.8367   |   \n",
       "проблема          |   проблема        0.6630   |   \n",
       "билайн            |   билайн          0.7044   |   \n",
-      "уже               |   уже             0.8313   |   \n"
+      "уже               |   уже             0.8313   |   \n",
+      "раньше            |   раньше          0.7320   |   \n",
+      "рам               |   нам             0.7039   |   \n",
+      "щас               |   щас             0.8326   |   \n",
+      "купил             |   купил           0.6966   |   \n",
+      "ты                |   ты              0.8728   |   \n",
+      "зовут             |   зовут           0.7649   |   \n",
+      "короче            |   короче          0.7234   |   \n",
+      "размыто           |   размыто         0.1835   |   \n",
+      "давай             |   давай           0.7630   |   \n",
+      "отдать            |   отдать          0.4711   |   \n",
+      "привет            |   привет          0.7301   |   \n",
+      "не                |   не              0.8619   |   \n",
+      "да                |   да              0.8694   |   \n",
+      "будете            |   будете          0.7364   |   \n",
+      "связи             |   связи           0.7597   |   \n",
+      "колывань          |   колываешь       0.1670   |   \n",
+      "меня              |   меня            0.7948   |   \n",
+      "напиши            |   напиши          0.7292   |   \n",
+      "знаю              |   знаю            0.7961   |   \n",
+      "мамой             |   мамой           0.7615   |   \n",
+      "не                |   не              0.8673   |   \n",
+      "ты                |   ты              0.8716   |   \n",
+      "только            |   только          0.7333   |   \n",
+      "они               |   они             0.8335   |   \n"
      ]
     }
    ],
    "source": [
     "curve_id_to_hypotheses = predict(\n",
     "    greedy_generator__no_vocab, val_dataset, n_hypotheses=1, \n",
-    "    scores_to_prob=lambda pred, score: np.exp(-score), n_examples=15)"
+    "    scores_to_prob=lambda pred, score: np.exp(-score), n_examples=N_EXAMPLES)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.925"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_mmr(\n",
+    "    remove_scores_from_results(curve_id_to_hypotheses), \n",
+    "    val_default_targets[:N_EXAMPLES])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -467,12 +558,36 @@
       "она               |   она             0.9011   |   онассис         0.0013   |   оная            0.0013   |   онам            0.0012   |   \n",
       "проблема          |   проблема        0.8468   |   проблемы        0.0031   |   проблема-то     0.0011   |   проблемам       0.0014   |   \n",
       "билайн            |   билайн          0.8468   |   биоразнообразие 0.0006   |   библа           0.0072   |   биоразнообразия 0.0003   |   \n",
-      "уже               |   уже             0.9064   |   ужеобразные     0.0014   |   уже-уже         0.0012   |   ужей            0.0012   |   \n"
+      "уже               |   уже             0.9064   |   ужеобразные     0.0014   |   уже-уже         0.0012   |   ужей            0.0012   |   \n",
+      "раньше            |   раньше          0.8657   |   ранешенько      0.0014   |   ранишь          0.0042   |   раньше-то       0.0012   |   \n",
+      "рам               |   нам             0.7396   |   нас             0.0760   |   рам             0.0335   |   наматрасник     0.0001   |   \n",
+      "щас               |   щас             0.9419   |   щажение         0.0013   |   щаного          0.0006   |   щаденко         0.0004   |   \n",
+      "купил             |   купил           0.7817   |   купили          0.0354   |   купила          0.0165   |   купить          0.0128   |   \n",
+      "ты                |   ты              0.9104   |   ты-таки         0.0007   |   трын-трава      0.0002   |   ты-то           0.0006   |   \n",
+      "зовут             |   зовут           0.8996   |   зовут-то        0.0012   |   зовутся         0.0012   |   зовусь          0.0013   |   \n",
+      "короче            |   короче          0.8362   |   коромысел       0.0014   |   короед          0.0027   |   корочу          0.0019   |   \n",
+      "размыто           |   размыто         0.2740   |   размыть         0.1901   |   размыла         0.1489   |   размыл          0.0867   |   \n",
+      "давай             |   давай           0.8700   |   давай-давай     0.0003   |   давайся         0.0013   |   давайте         0.0011   |   \n",
+      "отдать            |   отдать          0.5606   |   отжать          0.2723   |   отжал           0.0127   |   отдавать        0.0017   |   \n",
+      "привет            |   привет          0.8450   |   привет-пока     0.0008   |   привет-привет   0.0004   |   приветик        0.0012   |   \n",
+      "не                |   не              0.8842   |   нее             0.0107   |   нехемия         0.0003   |   нехарактерен    0.0000   |   \n",
+      "да                |   да              0.8947   |   дам             0.0014   |   дан             0.0014   |   дак             0.0014   |   \n",
+      "будете            |   будете          0.8685   |   будет-то        0.0010   |   будем           0.0027   |   будешь-то       0.0005   |   \n",
+      "связи             |   связи           0.8859   |   связочного      0.0005   |   свяжи           0.0026   |   связист         0.0011   |   \n",
+      "колывань          |   колывани        0.5530   |   колыванов       0.0507   |   колывань        0.0457   |   кровать         0.0214   |   \n",
+      "меня              |   меня            0.8577   |   меннонитов      0.0008   |   меннониты       0.0007   |   меняя           0.0024   |   \n",
+      "напиши            |   напиши          0.8690   |   напиши-ка       0.0012   |   напишите        0.0015   |   напишу          0.0026   |   \n",
+      "знаю              |   знаю            0.9134   |   знаю-знаю       0.0012   |   знать           0.0036   |   знают           0.0032   |   \n",
+      "мамой             |   мамой           0.8660   |   мамору          0.0017   |   маторин         0.0011   |   мамочку         0.0010   |   \n",
+      "не                |   не              0.8892   |   нее             0.0055   |   нехирургические 0.0000   |   нехирургическое 0.0000   |   \n",
+      "ты                |   ты              0.9095   |   ты-таки         0.0007   |   ты-то           0.0005   |   тык             0.0013   |   \n",
+      "только            |   только          0.8676   |   только-то       0.0012   |   тольятти        0.0011   |   толбухин        0.0010   |   \n",
+      "они               |   они             0.8998   |   онищенко        0.0012   |   онигири         0.0013   |   они-то          0.0013   |   \n"
      ]
     }
    ],
    "source": [
-    "n_examples = 15\n",
+    "n_examples = N_EXAMPLES\n",
     "normalization_factor = 0.5\n",
     "beamsize = 6\n",
     "\n",
@@ -484,7 +599,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9295"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_mmr(\n",
+    "    remove_scores_from_results(curve_id_to_hypotheses), \n",
+    "    val_default_targets[:N_EXAMPLES])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -492,7 +629,13 @@
      "output_type": "stream",
      "text": [
       "target                pred1                        pred2                        pred3                        pred4                        \n",
-      "---------------------------------------------------------------------------------------------------------------------------------------\n",
+      "---------------------------------------------------------------------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "на                |   на              0.8729   |   нан             0.0014   |   нак             0.0013   |   наз             0.0012   |   \n",
       "все               |   все             0.8297   |   всем            0.0015   |   вссе            0.0012   |   всен            0.0012   |   \n",
       "добрый            |   добрый          0.7269   |   добрым          0.0032   |   добрыйо         0.0011   |   добрыйи         0.0010   |   \n",
@@ -508,12 +651,36 @@
       "она               |   она             0.8367   |   онат            0.0012   |   онас            0.0012   |   онао            0.0012   |   \n",
       "проблема          |   проблема        0.6630   |   проблемы        0.0024   |   проблемам       0.0011   |   проблеман       0.0010   |   \n",
       "билайн            |   билайн          0.7044   |   билайк          0.0064   |   билайне         0.0023   |   билайна         0.0015   |   \n",
-      "уже               |   уже             0.8313   |   ужеи            0.0013   |   ужео            0.0012   |   ужеб            0.0012   |   \n"
+      "уже               |   уже             0.8313   |   ужеи            0.0013   |   ужео            0.0012   |   ужеб            0.0012   |   \n",
+      "раньше            |   раньше          0.7320   |   раньшее         0.0013   |   ранье           0.0027   |   раньшей         0.0012   |   \n",
+      "рам               |   нам             0.7039   |   нас             0.0730   |   рам             0.0318   |   наи             0.0028   |   \n",
+      "щас               |   щас             0.8326   |   щаса            0.0012   |   щаси            0.0012   |   щасб            0.0012   |   \n",
+      "купил             |   купил           0.6966   |   купили          0.0302   |   купила          0.0141   |   купить          0.0108   |   \n",
+      "ты                |   ты              0.8728   |   тыб             0.0012   |   тыи             0.0012   |   тыф             0.0012   |   \n",
+      "зовут             |   зовут           0.7649   |   зовута          0.0014   |   зовуть          0.0011   |   зовуты          0.0011   |   \n",
+      "короче            |   короче          0.7234   |   корочей         0.0019   |   корочее         0.0012   |   корочу          0.0017   |   \n",
+      "размыто           |   размыто         0.1835   |   размыть         0.1296   |   размыла         0.1043   |   размымил        0.0524   |   \n",
+      "давай             |   давай           0.7630   |   давайе          0.0011   |   давайс          0.0011   |   давайь          0.0010   |   \n",
+      "отдать            |   отдать          0.4711   |   отжать          0.2082   |   отжасть         0.0122   |   отжаль          0.0125   |   \n",
+      "привет            |   привет          0.7301   |   приветик        0.0009   |   привете         0.0012   |   привета         0.0011   |   \n",
+      "не                |   не              0.8619   |   нее             0.0100   |   нео             0.0014   |   нес             0.0013   |   \n",
+      "да                |   да              0.8694   |   дан             0.0014   |   дам             0.0014   |   дак             0.0013   |   \n",
+      "будете            |   будете          0.7364   |   будетеле        0.0010   |   будетем         0.0012   |   будетей         0.0012   |   \n",
+      "связи             |   связи           0.7597   |   связин          0.0032   |   связит          0.0024   |   связил          0.0018   |   \n",
+      "колывань          |   колываешь       0.1670   |   колывать        0.1306   |   колывает        0.0731   |   колывают        0.0191   |   \n",
+      "меня              |   меня            0.7948   |   меняя           0.0021   |   менял           0.0012   |   меням           0.0012   |   \n",
+      "напиши            |   напиши          0.7292   |   напишин         0.0016   |   напишу          0.0022   |   напишит         0.0012   |   \n",
+      "знаю              |   знаю            0.7961   |   знать           0.0030   |   знают           0.0027   |   знаюл           0.0011   |   \n",
+      "мамой             |   мамой           0.7615   |   мамтой          0.0025   |   мамойа          0.0012   |   мамойж          0.0011   |   \n",
+      "не                |   не              0.8673   |   нее             0.0052   |   ну              0.0036   |   нег             0.0013   |   \n",
+      "ты                |   ты              0.8716   |   тыб             0.0012   |   тык             0.0012   |   тыд             0.0012   |   \n",
+      "только            |   только          0.7333   |   толькое         0.0011   |   толькоь         0.0010   |   толькоб         0.0010   |   \n",
+      "они               |   они             0.8335   |   оние            0.0015   |   онии            0.0015   |   онир            0.0013   |   \n"
      ]
     }
    ],
    "source": [
-    "n_examples = 15\n",
+    "n_examples = N_EXAMPLES\n",
     "normalization_factor = 0.5\n",
     "\n",
     "curve_id_to_hypotheses = predict(\n",
@@ -524,16 +691,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9272500000000001"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_mmr(\n",
+    "    remove_scores_from_results(curve_id_to_hypotheses), \n",
+    "    val_default_targets[:N_EXAMPLES])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('на', 0.8729147558351656), ('нас', 0.001725468331042225), ('неа', 0.001583207265670061), ('нам', 0.0012425854680964096), ('нав', 0.0011460283846146304), ('наа', 0.0011295282480705778)]\n",
+      "[('на', 0.8729092829704758), ('нан', 0.001368771994223684), ('нак', 0.0012917323799744398), ('наз', 0.0012406942298722762), ('нас', 0.0012353012474402444), ('нам', 0.0012299452188896467)]\n",
       "\n",
-      "[('все', 0.8300481755078998), ('всем', 0.0012949032335612689), ('всен', 0.001187697357643541), ('всеб', 0.0011859830734336145), ('всех', 0.0011663816457048192), ('всек', 0.0011443660631516442)]\n"
+      "[('все', 0.8296962529135575), ('всем', 0.0014837110957669436), ('вссе', 0.0012305261855713769), ('всен', 0.001221845251885779), ('всел', 0.001162842077791718), ('всев', 0.001159402571349152)]\n"
      ]
     }
    ],
@@ -542,13 +731,6 @@
     "print()\n",
     "print(curve_id_to_hypotheses[1][:6])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -570,1437 +752,11 @@
     "2. Даже если beamsize = n_classes, beamsearch не оценивает явно вероятность всех слов, потому что из-за over confidence вероятности некоторых возможных токенов оказываются нулевыми и эта ветка обрывается\n",
     "---------------"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Evaluate models separately and as a pair"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 126,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(cpu_count())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 128,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "val_default_targets = get_targets(val_default_dataset, char_tokenizer)\n",
-    "val_extra_targets = get_targets(val_extra_dataset, char_tokenizer)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_predictions = weights_to_raw_predictions(\n",
-    "    grid_name = \"default\",\n",
-    "    model_getter=get_m1_bigger_model,\n",
-    "    weights_path = os.path.join(MODELS_ROOT, \"m1_bigger/m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt\"),\n",
-    "    char_tokenizer=char_tokenizer,\n",
-    "    dataset=val_default_dataset,\n",
-    "    generator_ctor=GreedyGenerator,\n",
-    "    n_workers=4\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 135,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8531223449447749"
-      ]
-     },
-     "execution_count": 135,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "default_MMR =  get_mmr(default_predictions, val_default_targets)\n",
-    "default_MMR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 136,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_predictions_best_bigger = default_predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 137,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_predictions_best_bigger_clean, _ = separate_out_vocab_all_crvs(default_predictions_best_bigger, vocab_set)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 138,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8784"
-      ]
-     },
-     "execution_count": 138,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sum(bool(el) for el in default_predictions_best_bigger_clean)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 182,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 9416/9416 [04:08<00:00, 37.90it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "default_predictions = weights_to_raw_predictions(\n",
-    "    grid_name = \"default\",\n",
-    "    model_getter=get_m1_smaller_model,\n",
-    "    weights_path = os.path.join(MODELS_ROOT, \"m1_smaller/m1_smaller_v2_2023_11_11_17_43_35_0_33179_default_l2_1e_05_ls0_02.pt\"),\n",
-    "    char_tokenizer=char_tokenizer,\n",
-    "    dataset=val_default_dataset,\n",
-    "    generator_ctor=GreedyGenerator,\n",
-    "    n_workers=4\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 183,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_predictions_clean, _ = separate_out_vocab_all_crvs(default_predictions, vocab_set)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 184,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8449"
-      ]
-     },
-     "execution_count": 184,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sum(bool(el) for el in default_predictions_clean)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 185,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8221112999150383"
-      ]
-     },
-     "execution_count": 185,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "default_MMR =  get_mmr(default_predictions, val_default_targets)\n",
-    "default_MMR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 110,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# grid_name = \"default\"\n",
-    "# model_getter = get_m1_bigger_model\n",
-    "# weights_path = os.path.join(MODELS_ROOT, \"m1_bigger/m1_bigger_v2__2023_11_11__13_17_50__0.13845_default_l2_0_ls0_switch_0.pt\")\n",
-    "# model = model_getter(device, weights_path)\n",
-    "# grid_name_to_greedy_generator = {grid_name: GreedyGenerator(model, char_tokenizer, device)}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 111,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 9416/9416 [05:02<00:00, 31.10it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# default_predictions = predict_greedy_raw_multiproc(val_default_dataset,\n",
-    "#                                                     grid_name_to_greedy_generator,\n",
-    "#                                                     num_workers=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name = \"extra\"\n",
-    "model_getter = get_m1_model\n",
-    "weights_path = os.path.join(MODELS_ROOT, \"m1_v2/m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt\")\n",
-    "model = model_getter(device, weights_path)\n",
-    "grid_name_to_greedy_generator = {grid_name: GreedyGenerator(model, char_tokenizer, device)}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 584/584 [00:18<00:00, 31.60it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "extra_predictions = predict_raw_mp(val_extra_dataset,\n",
-    "                                   grid_name_to_greedy_generator,\n",
-    "                                   num_workers=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.851027397260274"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "extra_MMR = get_mmr(extra_predictions, val_extra_targets)\n",
-    "extra_MMR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_preds = merge_default_and_extra_preds(default_predictions, extra_predictions, val_default_dataset.grid_name_idxs, val_extra_dataset.grid_name_idxs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_targets = None\n",
-    "with open(os.path.join(DATA_ROOT, \"valid.ref\"), 'r', encoding='utf-8') as f:\n",
-    "    all_targets = f.read().splitlines() "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8512"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "full_MMR = get_mmr(all_preds, all_targets)\n",
-    "full_MMR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 365,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "19"
-      ]
-     },
-     "execution_count": 365,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "max(len(el) for el in all_targets)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "{\"m1_v2/best_model__2023_11_09__10_36_02__0.14229_default_switch_2_try_2.pt\": 0.8512107051826678,\n",
-    " \"m1_v2/m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt\": 0.851027397260274,\n",
-    " \n",
-    " \"m1_bigger/m1_bigger_v2__2023_11_10__13_38_32__0.50552_default_l2_5e-05_ls0.045_switch_0.pt\": 0.810429056924384,\n",
-    " \"m1_bigger/m1_bigger_v2__2023_11_10__16_36_38__0.49848_default_l2_5e-05_ls0.045_switch_0.pt\": 0.818500424808836,\n",
-    " \"m1_bigger/m1_bigger_v2__2023_11_10__21_51_01__0.49382_default_l2_5e-05_ls0.045_switch_0.pt\": 0.8210492778249787,\n",
-    " \n",
-    " \"m1_bigger/m1_bigger_v2__2023_11_11__13_17_50__0.13845_default_l2_0_ls0_switch_0.pt\": 0.8512107051826678,\n",
-    " \"m1_bigger/m1_bigger_v2__2023_11_11__14_29_37__0.13679_default_l2_0_ls0_switch_0.pt\": 0.8531223449447749,\n",
-    " \n",
-    " \"m1_smaller/m1_smaller_v2_2023_11_11_17_43_35_0_33179_default_l2_1e_05_ls0_02.pt\": 0.8221112999150383}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Let's create a greedy submission"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from typing import Set, List, Tuple"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name = \"default\"\n",
-    "model_getter = get_m1_model\n",
-    "weights_path = os.path.join(MODELS_ROOT, \"m1_v2/m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt\")\n",
-    "model = model_getter(device, weights_path)\n",
-    "grid_name_to_greedy_generator = {grid_name: GreedyGenerator(model, char_tokenizer, device)}\n",
-    "default_test_predictions = predict_raw_mp(test_default_dataset,\n",
-    "                                          grid_name_to_greedy_generator,\n",
-    "                                          num_workers=3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 627/627 [00:20<00:00, 30.18it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "grid_name = \"extra\"\n",
-    "model_getter = get_m1_model\n",
-    "weights_path = os.path.join(MODELS_ROOT, \"m1_v2/m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt\")\n",
-    "model = model_getter(device, weights_path)\n",
-    "grid_name_to_greedy_generator = {grid_name: GreedyGenerator(model, char_tokenizer, device)}\n",
-    "extra_test_predictions = predict_raw_mp(test_extra_dataset,\n",
-    "                                        grid_name_to_greedy_generator,\n",
-    "                                        num_workers=3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_test_preds = merge_default_and_extra_preds(default_test_predictions, extra_test_predictions, test_default_dataset.grid_name_idxs, test_extra_dataset.grid_name_idxs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 69,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vocab_set = get_vocab_set(os.path.join(DATA_ROOT, \"voc.txt\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 91,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clean_test_preds, invalid_test_preds = separate_out_vocab_all_crvs(all_test_preds, vocab_set)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 92,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['на'],\n",
-       " ['что'],\n",
-       " ['опоздания'],\n",
-       " ['сколько'],\n",
-       " [],\n",
-       " ['не'],\n",
-       " ['как'],\n",
-       " ['садовод'],\n",
-       " ['заметил'],\n",
-       " ['ваги']]"
-      ]
-     },
-     "execution_count": 92,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "clean_test_preds[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 81,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "augment_list = None\n",
-    "with open(r\"..\\data\\submissions\\sample_submission.csv\", 'r', encoding = 'utf-8') as f:\n",
-    "    augment_lines = f.read().splitlines()\n",
-    "augment_list = [line.split(\",\") for line in augment_lines]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 96,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "augmented_test_preds = append_preds(clean_test_preds, augment_list, limit = 4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 97,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['на', 'неа', 'на', 'ненка'],\n",
-       " ['что', 'часто', 'частого', 'чисто'],\n",
-       " ['опоздания', 'опоздания', 'опозданиям', 'оприходования'],\n",
-       " ['сколько', 'сколько', 'сокольского', 'свердловского'],\n",
-       " ['дремать', 'дописать', 'донимать', 'дюрренматт'],\n",
-       " ['не', 'неук', 'нк', 'ненка'],\n",
-       " ['как', 'как', 'капак', 'капе'],\n",
-       " ['садовод', 'спародировал', 'садовод', 'сурдоперевод'],\n",
-       " ['заметил', 'знаменито', 'знаменитого', 'замерил'],\n",
-       " ['ваги', 'ваенги', 'венгрии', 'ванги']]"
-      ]
-     },
-     "execution_count": 97,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "augmented_test_preds[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "submission_name = \"m1_v2__0.14229_deault__0.14301_extra__greedy.csv\"\n",
-    "out_path = rf\"..\\data\\submissions\\{submission_name}\"\n",
-    "create_submission(augmented_test_preds, out_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# BeamSearch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from typing import Tuple, List\n",
-    "def remove_beamsearch_probs(preds: List[List[Tuple[float, str]]]) -> List[List[str]]:\n",
-    "    new_preds = []\n",
-    "    for pred_line in preds:\n",
-    "        new_preds_line = []\n",
-    "        for _, word in pred_line:\n",
-    "            new_preds_line.append(word)\n",
-    "        new_preds.append(new_preds_line)\n",
-    "    return new_preds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def patch_wrong_prediction_shape(prediciton):\n",
-    "    return [pred_el[0] for pred_el in prediciton]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Beamsearch Evaluation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 372,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MAX_VAL_WORD_LEN = max(len(el) for el in all_targets)\n",
-    "\n",
-    "generator_kwargs = {\n",
-    "    'max_steps_n': MAX_VAL_WORD_LEN+1,\n",
-    "    'return_hypotheses_n': 7,\n",
-    "    'beamsize': 6,\n",
-    "    'normalization_factor': 0.5,\n",
-    "    'verbose': False\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 373,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name_to_val_dataset = {\n",
-    "    'default': val_default_dataset,\n",
-    "    'extra': val_extra_dataset\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 374,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 9416/9416 [41:23<00:00,  3.79it/s] \n"
-     ]
-    }
-   ],
-   "source": [
-    "import pickle\n",
-    "\n",
-    "bs_params = [\n",
-    "    (\"default\", get_m1_bigger_model, \"m1_bigger/m1_bigger_v2__2023_11_12__14_51_49__0.13115__greed_acc_0.86034__default_l2_0_ls0_switch_2.pt\"),\n",
-    "]\n",
-    "\n",
-    "\n",
-    "for grid_name, model_getter, weights_f_name in bs_params:\n",
-    "\n",
-    "    bs_preds_path = os.path.join(\"../data/saved_beamsearch_validation_results/\",\n",
-    "                                f\"{weights_f_name.replace('/', '__')}.pkl\")\n",
-    "    \n",
-    "    if os.path.exists(bs_preds_path):\n",
-    "        print(f\"Path {bs_preds_path} exists. Skipping.\")\n",
-    "        continue\n",
-    "\n",
-    "    bs_predictions = weights_to_raw_predictions(\n",
-    "        grid_name = grid_name,\n",
-    "        model_getter=model_getter,\n",
-    "        weights_path = os.path.join(MODELS_ROOT, weights_f_name),\n",
-    "        char_tokenizer=char_tokenizer,\n",
-    "        dataset=grid_name_to_val_dataset[grid_name],\n",
-    "        generator_ctor=BeamGenerator,\n",
-    "        n_workers=4,\n",
-    "        generator_kwargs=generator_kwargs\n",
-    "    )\n",
-    "\n",
-    "    with open(bs_preds_path, 'wb') as f:\n",
-    "        pickle.dump(bs_predictions, f, protocol=pickle.HIGHEST_PROTOCOL)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 375,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8929800339847141"
-      ]
-     },
-     "execution_count": 375,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "preds_name = \"m1_bigger__m1_bigger_v2__2023_11_12__14_51_49__0.13115__greed_acc_0.86034__default_l2_0_ls0_switch_2.pt.pkl\"\n",
-    "bs_preds_path = os.path.join(\"../data/saved_beamsearch_validation_results/\",\n",
-    "                                preds_name)\n",
-    "with open(bs_preds_path, 'rb') as f:\n",
-    "    default_valid_preds_bs = pickle.load(f)\n",
-    "\n",
-    "default_valid_preds_bs = patch_wrong_prediction_shape(default_valid_preds_bs)\n",
-    "default_valid_preds_bs = remove_beamsearch_probs(default_valid_preds_bs)\n",
-    "default_valid_preds_bs, _ = separate_out_vocab_all_crvs(default_valid_preds_bs, vocab_set)\n",
-    "get_mmr(default_valid_preds_bs, val_default_targets)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 340,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.8876027397260277"
-      ]
-     },
-     "execution_count": 340,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "preds_name = \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\"\n",
-    "bs_preds_path = os.path.join(\"../data/saved_beamsearch_validation_results/\",\n",
-    "                                preds_name)\n",
-    "with open(bs_preds_path, 'rb') as f:\n",
-    "    extra_valid_preds_bs = pickle.load(f)\n",
-    "\n",
-    "extra_valid_preds_bs = patch_wrong_prediction_shape(extra_valid_preds_bs)\n",
-    "extra_valid_preds_bs = remove_beamsearch_probs(extra_valid_preds_bs)\n",
-    "extra_valid_preds_bs, _ = separate_out_vocab_all_crvs(extra_valid_preds_bs, vocab_set)\n",
-    "get_mmr(extra_valid_preds_bs, val_extra_targets)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# {\n",
-    "#     \"m1_smaller__m1_smaller_v2_2023_11_12_01_21_45_0_31891_default_l2_1e_05_ls0_02.pt.pkl\": 0.8811533559898118,\n",
-    "#     \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\": 0.8835960067969484,\n",
-    "#     \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\": 0.8900881478334822,\n",
-    "#     \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\": 0.8871590909090984,\n",
-    "#     \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\": 0.887674171622777,\n",
-    "#     \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\": 0.8877740016992428,\n",
-    "    \n",
-    "    \n",
-    "#     \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\": 0.8864383561643838,\n",
-    "#     \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\": 0.8876027397260277\n",
-    "    \n",
-    "# }"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__14_51_49__0.13115__greed_acc_0.86034__default_l2_0_ls0_switch_2.pt.pkl\", #: 0.8929800339847141,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt.pkl\", #: 0.8914698385726496,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",  #: 0.8900881478334822,\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",  #: E 0.8877740016992428,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",  #: 0.887674171622777,\n",
-    "        # \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\",  #: 0.8871590909090984,\n",
-    "        \"m1_smaller__m1_smaller_v2__2023_11_12__17_40_42__0.30909_default_l2_1e-05_ls0.02_switch_0.pt.pkl\",  # 0.8849384027187835\n",
-    "        # \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\",  #: 0.8835960067969484,\n",
-    "        # \"m1_smaller__m1_smaller_v2_2023_11_12_01_21_45_0_31891_default_l2_1e_05_ls0_02.pt.pkl\",  #: 0.8811533559898118,\n",
-    "        ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\"\n",
-    "        ]\n",
-    "}\n",
-    "\n",
-    "# Отранжированы по качесту beamsearch на валидации"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pickle\n",
-    "\n",
-    "default_idxs = val_default_dataset.grid_name_idxs\n",
-    "extra_idxs = val_extra_dataset.grid_name_idxs \n",
-    "\n",
-    "grid_name_to_augmented_preds = {}\n",
-    "\n",
-    "for grid_name in ('default', 'extra'):\n",
-    "    bs_pred_list = []\n",
-    "\n",
-    "    for f_name in grid_name_to_ranged_bs_model_preds_paths[grid_name]:\n",
-    "        f_path = os.path.join(\"../data/saved_beamsearch_validation_results/\", f_name)\n",
-    "        with open(f_path, 'rb') as f:\n",
-    "            bs_pred_list.append(pickle.load(f))\n",
-    "        \n",
-    "    bs_pred_list = [patch_wrong_prediction_shape(bs_preds) for bs_preds in bs_pred_list] \n",
-    "    bs_pred_list = [remove_beamsearch_probs(bs_preds) for bs_preds in bs_pred_list]\n",
-    "    bs_pred_list = [separate_out_vocab_all_crvs(bs_preds, vocab_set)[0] for bs_preds in bs_pred_list]\n",
-    "\n",
-    "\n",
-    "    augmented_preds = bs_pred_list.pop(0)\n",
-    "\n",
-    "    while bs_pred_list:\n",
-    "        augmented_preds = append_preds(augmented_preds, bs_pred_list.pop(0))\n",
-    "\n",
-    "    grid_name_to_augmented_preds[grid_name] = augmented_preds\n",
-    "\n",
-    "\n",
-    "full_preds = merge_default_and_extra_preds(\n",
-    "    grid_name_to_augmented_preds['default'],\n",
-    "    grid_name_to_augmented_preds['extra'],\n",
-    "    default_idxs,\n",
-    "    extra_idxs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_preds[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from collections import defaultdict\n",
-    "\n",
-    "n_preds_in_line_dict = defaultdict(int)\n",
-    "\n",
-    "for line in full_preds:\n",
-    "    n_preds_in_line_dict[len(line)] += 1\n",
-    "\n",
-    "print(n_preds_in_line_dict)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_targets = None\n",
-    "with open(os.path.join(DATA_ROOT, \"valid.ref\"), 'r', encoding='utf-8') as f:\n",
-    "    all_targets = f.read().splitlines() "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "get_mmr(full_preds, all_targets)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.8900881478334822,\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",#: 0.8877740016992428,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.887674171622777,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\",#: 0.8871590909090984,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8835960067969484,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_01_21_45_0_31891_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8811533559898118,\n",
-    "        ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\"\n",
-    "        ]\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "0.8936010000000082\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "``` python\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",#: 0.8877740016992428,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.8900881478334822,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.887674171622777,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\",#: 0.8871590909090984,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8835960067969484,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_01_21_45_0_31891_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8811533559898118,\n",
-    "        ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\"\n",
-    "        ]\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "0.892801000000009\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "``` python\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.8900881478334822,\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",#: 0.8877740016992428,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",#: 0.887674171622777,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8835960067969484,\n",
-    "        \"m1_smaller__m1_smaller_v2_2023_11_12_01_21_45_0_31891_default_l2_1e_05_ls0_02.pt.pkl\",#: 0.8811533559898118,\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\",#: 0.8871590909090984,\n",
-    "        ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\"\n",
-    "        ]\n",
-    "}\n",
-    "\n",
-    "# должны ранжироваться по качесту beamsearch на валидации\n",
-    "```\n",
-    "\n",
-    "0.8936000000000084"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Beamsearch test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 343,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MAX_WORD_LEN = 36\n",
-    "\n",
-    "generator_kwargs = {\n",
-    "    'max_steps_n': MAX_WORD_LEN - 1,\n",
-    "    'return_hypotheses_n': 7,\n",
-    "    'beamsize': 6,\n",
-    "    'normalization_factor': 0.5,\n",
-    "    'verbose': False\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 344,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name_to_test_dataset = {\n",
-    "    'default': test_default_dataset,\n",
-    "    'extra': test_extra_dataset\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 356,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 627/627 [06:02<00:00,  1.73it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pickle\n",
-    "\n",
-    "bs_params = [\n",
-    "    (\"extra\", get_m1_bigger_model, \"m1_bigger/m1_bigger_v2__2023_11_12__02_27_14__0.13413_extra_l2_0_ls0_switch_1.pt\"),\n",
-    "\n",
-    "    # \"m1_smaller__m1_smaller_v2_2023_11_12_08_17_33_0_31223_default_l2_1e_05_ls0_02.pt.pkl\": 0.8835960067969484,\n",
-    "    # \"m1_bigger__m1_bigger_v2__2023_11_11__15_53_07__0.13636_default_l2_0_ls0_switch_0.pt.pkl\": 0.8871590909090984,\n",
-    "    # \"m1_bigger__m1_bigger_v2__2023_11_11__16_45_33__0.13721_extra_l2_0_ls0_switch_0.pt.pkl\": 0.8864383561643838,\n",
-    "]\n",
-    "\n",
-    "\n",
-    "for grid_name, model_getter, weights_f_name in bs_params:\n",
-    "\n",
-    "    bs_preds_path = os.path.join(\"../data/saved_beamsearch_results/\",\n",
-    "                                f\"{weights_f_name.replace('/', '__')}.pkl\")\n",
-    "    \n",
-    "    if os.path.exists(bs_preds_path):\n",
-    "        print(f\"Path {bs_preds_path} exists. Skipping.\")\n",
-    "        continue\n",
-    "\n",
-    "    bs_predictions = weights_to_raw_predictions(\n",
-    "        grid_name = grid_name,\n",
-    "        model_getter=model_getter,\n",
-    "        weights_path = os.path.join(MODELS_ROOT, weights_f_name),\n",
-    "        char_tokenizer=char_tokenizer,\n",
-    "        dataset=grid_name_to_test_dataset[grid_name],\n",
-    "        generator_ctor=BeamGenerator,\n",
-    "        n_workers=4,\n",
-    "        generator_kwargs=generator_kwargs\n",
-    "    )\n",
-    "\n",
-    "    with open(bs_preds_path, 'wb') as f:\n",
-    "        pickle.dump(bs_predictions, f, protocol=pickle.HIGHEST_PROTOCOL)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 161,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(9373, 9193)"
-      ]
-     },
-     "execution_count": 161,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# len(clean_default_test_predictions), sum(bool(el) for el in clean_default_test_predictions)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vocab_set = get_vocab_set(os.path.join(DATA_ROOT, \"voc.txt\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 169,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "defaultdict(<class 'int'>, {4: 7404, 3: 1032, 2: 840, 1: 577, 0: 147})\n"
-     ]
-    }
-   ],
-   "source": [
-    "# from collections import defaultdict\n",
-    "\n",
-    "# n_preds_in_line_dict = defaultdict(int)\n",
-    "\n",
-    "# for line in clean_test_predictions:\n",
-    "#     n_preds_in_line_dict[len(line)] += 1\n",
-    "\n",
-    "# print(n_preds_in_line_dict)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 170,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "old_preds_path = os.path.join(DATA_ROOT, \"test_raw_pred___best_model__2023_11_04__18_31_37__0.02530_default_switch_2.pt__best_model__2023_11_05__07_55_13__0.02516_extra_switch_2__with_pad_cutting.pt.pkl\")\n",
-    "with open(old_preds_path, 'rb') as f:\n",
-    "    old_preds_list = pickle.load(f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 171,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "old_preds_list = remove_beamsearch_probs(old_preds_list)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 172,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "old_preds_list_valid, old_preds_list_invalid = separate_out_vocab_all_crvs(old_preds_list, vocab_set)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 176,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# submission_name = \"default__m1_bigger_13679__m1_v2__14229___extra__14301___with_baseline__beam.csv\"\n",
-    "# out_path = rf\"..\\data\\submissions\\{submission_name}\"\n",
-    "# create_submission(clean_test_baseline_augmented, out_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Submission creation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "id 1\n",
-    "\n",
-    "```\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__14_29_37__0.13679_default_l2_0_ls0_switch_0.pt.pkl\",\n",
-    "        \n",
-    "    ],\n",
-    "    'extra': [\"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\"]\n",
-    "}\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "id 2\n",
-    "\n",
-    "```\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__14_29_37__0.13679_default_l2_0_ls0_switch_0.pt.pkl\",\n",
-    "        \n",
-    "    ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__02_27_14__0.13413_extra_l2_0_ls0_switch_1.pt.pkl\"\n",
-    "    ]\n",
-    "}\n",
-    "\n",
-    "# должны ранжироваться по качесту beamsearch на валидации\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "id 3\n",
-    "\n",
-    "```python\n",
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger_m1_bigger_v2_2023_11_12_14_51_49_0_13115_greed_acc_0_86034.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__14_29_37__0.13679_default_l2_0_ls0_switch_0.pt.pkl\",\n",
-    "        \n",
-    "    ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__02_27_14__0.13413_extra_l2_0_ls0_switch_1.pt.pkl\"\n",
-    "    ]\n",
-    "}\n",
-    "\n",
-    "# должны ранжироваться по качесту beamsearch на валидации\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 385,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "grid_name_to_ranged_bs_model_preds_paths = {\n",
-    "    'default': [\n",
-    "        \"m1_bigger_m1_bigger_v2_2023_11_12_14_51_49_0_13115_greed_acc_0_86034.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__12_30_29__0.13121__greed_acc_0.86098__default_l2_0_ls0_switch_2.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__22_18_35__0.13542_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_v2__m1_v2__2023_11_09__10_36_02__0.14229_default_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__00_39_33__0.13297_default_l2_0_ls0_switch_1.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_11__14_29_37__0.13679_default_l2_0_ls0_switch_0.pt.pkl\",\n",
-    "        \n",
-    "    ],\n",
-    "    'extra': [\n",
-    "        \"m1_v2__m1_v2__2023_11_09__17_47_40__0.14301_extra_l2_1e-05_switch_0.pt.pkl\",\n",
-    "        \"m1_bigger__m1_bigger_v2__2023_11_12__02_27_14__0.13413_extra_l2_0_ls0_switch_1.pt.pkl\"\n",
-    "    ]\n",
-    "}\n",
-    "\n",
-    "# должны ранжироваться по качесту beamsearch на валидации"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 386,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_idxs = test_default_dataset.grid_name_idxs\n",
-    "extra_idxs = test_extra_dataset.grid_name_idxs \n",
-    "\n",
-    "grid_name_to_augmented_preds = {}\n",
-    "\n",
-    "for grid_name in ('default', 'extra'):\n",
-    "    bs_pred_list = []\n",
-    "\n",
-    "    for f_name in grid_name_to_ranged_bs_model_preds_paths[grid_name]:\n",
-    "        f_path = os.path.join(\"../data/saved_beamsearch_results/\", f_name)\n",
-    "        with open(f_path, 'rb') as f:\n",
-    "            bs_pred_list.append(pickle.load(f))\n",
-    "        \n",
-    "    bs_pred_list = [patch_wrong_prediction_shape(bs_preds) for bs_preds in bs_pred_list] \n",
-    "    bs_pred_list = [remove_beamsearch_probs(bs_preds) for bs_preds in bs_pred_list]\n",
-    "    bs_pred_list = [separate_out_vocab_all_crvs(bs_preds, vocab_set)[0] for bs_preds in bs_pred_list]\n",
-    "\n",
-    "\n",
-    "    augmented_preds = bs_pred_list.pop(0)\n",
-    "\n",
-    "    while bs_pred_list:\n",
-    "        augmented_preds = append_preds(augmented_preds, bs_pred_list.pop(0))\n",
-    "\n",
-    "    grid_name_to_augmented_preds[grid_name] = augmented_preds\n",
-    "\n",
-    "\n",
-    "full_preds = merge_default_and_extra_preds(\n",
-    "    grid_name_to_augmented_preds['default'],\n",
-    "    grid_name_to_augmented_preds['extra'],\n",
-    "    default_idxs,\n",
-    "    extra_idxs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 387,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "defaultdict(<class 'int'>, {4: 8188, 3: 706, 2: 606, 1: 407, 0: 93})\n"
-     ]
-    }
-   ],
-   "source": [
-    "from collections import defaultdict\n",
-    "\n",
-    "n_preds_in_line_dict = defaultdict(int)\n",
-    "\n",
-    "for line in full_preds:\n",
-    "    n_preds_in_line_dict[len(line)] += 1\n",
-    "\n",
-    "print(n_preds_in_line_dict)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 388,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "baseline_preds = None\n",
-    "with open(r\"..\\data\\submissions\\sample_submission.csv\", 'r', encoding = 'utf-8') as f:\n",
-    "    baseline_preds = f.read().splitlines()\n",
-    "baseline_preds = [line.split(\",\") for line in augment_lines]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 389,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_preds = append_preds(full_preds, baseline_preds)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 390,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "create_submission(full_preds,\n",
-    "                  f\"../data/submissions/id3_with_baseline_without_old_preds\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 363,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_preds_augmentations = [\n",
-    "    \n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "executorch_examples_venv",
    "language": "python",
    "name": "python3"
   },
@@ -2014,7 +770,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Remove `n_coord_feats` argument from `models._get_transformer_bigger__v3`
* Update `get_mmr`: it divides the sum of scores by len(ref) instead of len(preds_list). It was possible to pass a small pre_list before and get a high score. Now it’s fixed
* Delete outdated prediction aggregation, model evaluation and submission creation code from word_generation_demo.ipynb
* Add mmr computation to word_generation_demo.ipynb
* Enhanced readability and made code a little cleaner in word_generators_v2.py
* Readme update: changed title to Neural glide typing