### PR TITLE
Make possible to configure precision

### DIFF
--- a/configs/train/train_google_2015.json
+++ b/configs/train/train_google_2015.json
@@ -40,5 +40,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/configs/train/train_indiswipe.json
+++ b/configs/train/train_indiswipe.json
@@ -40,5 +40,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/configs/train/train_nearest_only.json
+++ b/configs/train/train_nearest_only.json
@@ -40,5 +40,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/configs/train/train_traj_and_nearest.json
+++ b/configs/train/train_traj_and_nearest.json
@@ -40,5 +40,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/configs/train/train_traj_and_nearest_wd_2.json
+++ b/configs/train/train_traj_and_nearest_wd_2.json
@@ -1,8 +1,7 @@
 {
-    "logging_level": "INFO",
-    "experiment_name": "traj_and_trainable_weighted",
-    "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj.json",
-    "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_trainable_weighted__6_coord.json",
+    "experiment_name": "traj_and_nearest_wd_2",
+    "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj_and_nearest.json",
+    "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_nearest__6_coord.json",
 
     "num_classes": 35,
     "max_out_seq_len": 35,
@@ -37,8 +36,8 @@
     "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
-        "type": "Adam",
-        "params": {"lr":1e-4, "weight_decay":0}
+        "type": "AdamW",
+        "params": {"lr":1e-4, "weight_decay":0.0001}
     },
     "val_check_interval": 3000,
     "device": "cuda",

--- a/configs/train/train_traj_and_trainable_weighted_v2.json
+++ b/configs/train/train_traj_and_trainable_weighted_v2.json
@@ -1,5 +1,5 @@
 {
-    "logging_level": "DEBUG",
+    "logging_level": "INFO",
     "experiment_name": "traj_and_trainable_weighted_v2",
     "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj.json",
     "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_trainable_weighted_v2__6_coord.json",
@@ -41,5 +41,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/configs/train/train_traj_and_weighted.json
+++ b/configs/train/train_traj_and_weighted.json
@@ -40,5 +40,7 @@
         "params": {"lr":1e-4, "weight_decay":0}
     },
     "val_check_interval": 3000,
-    "device": "cuda"
+    "device": "cuda",
+    "trainer_precision": "16-mixed",
+    "float32_matmul_precision": "medium"
 }

--- a/src/train.py
+++ b/src/train.py
@@ -260,11 +260,14 @@ def main(train_config: dict) -> None:
         lr_scheduler_ctor=lr_scheduler_ctor, 
     )
 
+    torch.set_float32_matmul_precision(train_config['float32_matmul_precision'])
+
     trainer = Trainer(
     #     limit_train_batches = 400,  # for validating code before actual training
         log_every_n_steps = 100,
         num_sanity_val_steps=0,
         accelerator = 'gpu',
+        precision=train_config["trainer_precision"],
         # max_epochs=100,
         callbacks=callbacks,
         logger=tb_logger,


### PR DESCRIPTION
Make possible to configure precision. Using 16-mixed precsion along with medium float32_matmul_precision leads to 1.5 boost in training speed on the tested machine without decay in metrics.