### PR TITLE
Configurable model architecture

### DIFF
--- a/configs/decoder/transformer_v1.json
+++ b/configs/decoder/transformer_v1.json
@@ -1,0 +1,9 @@
+{
+    "type": "transformer_v1",
+    "params": {
+        "num_layers": 4,
+        "num_heads": 4,
+        "dim_feedforward": 128,
+        "dropout": 0.1
+    }
+}

--- a/configs/encoder/conformer.json
+++ b/configs/encoder/conformer.json
@@ -5,7 +5,7 @@
         "ffn_dim": 128,
         "num_layers": 4,
         "depthwise_conv_kernel_size": 31,
-        "dropout": 0.0,
+        "dropout": 0.1,
         "use_group_norm": false,
         "convolution_first": false
     }

--- a/configs/encoder/conformer.json
+++ b/configs/encoder/conformer.json
@@ -1,0 +1,12 @@
+{
+    "type": "conformer",
+    "params": {
+        "num_heads": 4,
+        "ffn_dim": 128,
+        "num_layers": 4,
+        "depthwise_conv_kernel_size": 31,
+        "dropout": 0.0,
+        "use_group_norm": false,
+        "convolution_first": false
+    }
+}

--- a/configs/encoder/transformer_v1.json
+++ b/configs/encoder/transformer_v1.json
@@ -1,0 +1,9 @@
+{
+    "type": "transformer_v1",
+    "params": {
+        "num_layers": 4,
+        "num_heads": 4,
+        "dim_feedforward": 128,
+        "dropout": 0.1
+    }
+}

--- a/configs/prediction/prediction_conf__google_2015.json
+++ b/configs/prediction/prediction_conf__google_2015.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__indiswipe.json
+++ b/configs/prediction/prediction_conf__indiswipe.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__nearest.json
+++ b/configs/prediction/prediction_conf__nearest.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__traj_and_nearest.json
+++ b/configs/prediction/prediction_conf__traj_and_nearest.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__traj_and_nearest__conformer.json
+++ b/configs/prediction/prediction_conf__traj_and_nearest__conformer.json
@@ -1,0 +1,35 @@
+{
+    "experiment_name": "traj_and_nearest",
+    "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj_and_nearest.json",
+    "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_nearest__6_coord.json",
+ 
+    "model_weights_path": "./checkpoints/traj_and_nearest__conformer1/epoch_end/traj_and_nearest__conformer1-epoch=3-val_loss=0.4743-val_word_level_accuracy=0.8347.ckpt",
+    "output_path": "./results/predictions/traj_and_nearest__conformer1/default/val/traj_and_nearest__conformer1-epoch=3-val_loss=0.4743-val_word_level_accuracy=0.8347.pkl",
+
+    "device": "cpu",
+    "data_path": "./data/data_preprocessed/valid.jsonl",
+
+    "grid_name": "default",
+    "voc_path": "./data/data_preprocessed/voc.txt",
+    "keyboard_tokenizer_path": "./tokenizers/keyboard/ru.json",
+    "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
+    "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
+    "bounding_boxes_path": "./data/data_preprocessed/key_bounding_boxes.json",
+    
+    "num_classes": 35,
+    "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/conformer.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
+
+    "use_vocab_for_generation": true,
+    "generator": {
+        "name": "beam",
+        "params": {
+            "max_steps_n": 35,
+            "beamsize": 6,
+            "normalization_factor": 0.5,
+            "return_hypotheses_n": null
+        }
+    }
+}

--- a/configs/prediction/prediction_conf__traj_and_trainable_weighted.json
+++ b/configs/prediction/prediction_conf__traj_and_trainable_weighted.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__traj_and_trainable_weighted_v2.json
+++ b/configs/prediction/prediction_conf__traj_and_trainable_weighted_v2.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/prediction/prediction_conf__traj_and_weighted.json
+++ b/configs/prediction/prediction_conf__traj_and_weighted.json
@@ -18,6 +18,9 @@
     
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json",
 
     "use_vocab_for_generation": true,
     "generator": {

--- a/configs/train/train_google_2015.json
+++ b/configs/train/train_google_2015.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_google_2015.json
+++ b/configs/train/train_google_2015.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_indiswipe.json
+++ b/configs/train/train_indiswipe.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_indiswipe.json
+++ b/configs/train/train_indiswipe.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_nearest_only.json
+++ b/configs/train/train_nearest_only.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_nearest_only.json
+++ b/configs/train/train_nearest_only.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_traj_and_nearest.json
+++ b/configs/train/train_traj_and_nearest.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_traj_and_nearest.json
+++ b/configs/train/train_traj_and_nearest.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_traj_and_nearest__conformer.json
+++ b/configs/train/train_traj_and_nearest__conformer.json
@@ -1,5 +1,5 @@
 {
-    "experiment_name": "traj_and_nearest__conformer",
+    "experiment_name": "traj_and_nearest__conformer1",
     "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj_and_nearest.json",
     "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_nearest__6_coord.json",
 
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_traj_and_nearest__conformer.json
+++ b/configs/train/train_traj_and_nearest__conformer.json
@@ -1,8 +1,7 @@
 {
-    "logging_level": "INFO",
-    "experiment_name": "traj_and_trainable_weighted_v2",
-    "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj.json",
-    "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_trainable_weighted_v2__6_coord.json",
+    "experiment_name": "traj_and_nearest__conformer",
+    "swipe_feature_extractor_factory_config_path": "./configs/feature_extractor/traj_and_nearest.json",
+    "swipe_point_embedder_config_path": "./configs/swipe_point_embedder/separate_traj_and_nearest__6_coord.json",
 
     "num_classes": 35,
     "max_out_seq_len": 35,
@@ -45,6 +44,8 @@
     "device": "cuda",
     "trainer_precision": "16-mixed",
     "float32_matmul_precision": "medium",
-    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+
+    
+    "encoder_config_path": "./configs/encoder/conformer.json",
     "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_traj_and_nearest_wd_2.json
+++ b/configs/train/train_traj_and_nearest_wd_2.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "AdamW",

--- a/configs/train/train_traj_and_nearest_wd_2.json
+++ b/configs/train/train_traj_and_nearest_wd_2.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_traj_and_trainable_weighted.json
+++ b/configs/train/train_traj_and_trainable_weighted.json
@@ -6,6 +6,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -43,5 +44,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_traj_and_trainable_weighted.json
+++ b/configs/train/train_traj_and_trainable_weighted.json
@@ -35,7 +35,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_traj_and_trainable_weighted_v2.json
+++ b/configs/train/train_traj_and_trainable_weighted_v2.json
@@ -35,7 +35,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/configs/train/train_traj_and_weighted.json
+++ b/configs/train/train_traj_and_weighted.json
@@ -5,6 +5,7 @@
 
     "num_classes": 35,
     "max_out_seq_len": 35,
+    "d_model": 128,
     "grid_name": "default",
     "grids_path": "./data/data_preprocessed/gridname_to_grid.json",
     "trajectory_features_statistics_path": "./data/data_preprocessed/trajectory_features_statistics.json",
@@ -42,5 +43,7 @@
     "val_check_interval": 3000,
     "device": "cuda",
     "trainer_precision": "16-mixed",
-    "float32_matmul_precision": "medium"
+    "float32_matmul_precision": "medium",
+    "encoder_config_path": "./configs/encoder/transformer_v1.json",
+    "decoder_config_path": "./configs/decoder/transformer_v1.json"
 }

--- a/configs/train/train_traj_and_weighted.json
+++ b/configs/train/train_traj_and_weighted.json
@@ -34,7 +34,6 @@
         }
     },
     "path_to_continue_checkpoint": null,
-    "model_name": "v3_nearest_and_traj_transformer_bigger",
     "label_smoothing": 0.045,
     "optimizer": {
         "type": "Adam",

--- a/src/model.py
+++ b/src/model.py
@@ -8,9 +8,6 @@ from modules.encoder_factory import encoder_factory
 from modules.decoder_factory import decoder_factory
 
 
-D_MODEL_V1 = 128
-
-
 
 def _get_mask(max_seq_len: int):
     """
@@ -168,6 +165,7 @@ def get_model_from_configs(
     n_classes: int,
     n_word_tokens: int,
     max_out_seq_len: int,
+    d_model: int,
     device: torch.device | str | None = None,
     weights_path: str | None = None
 ) -> EncoderDecoderTransformerLike:
@@ -194,6 +192,8 @@ def get_model_from_configs(
         Number of word tokens (vocabulary size for decoder input)
     max_out_seq_len: int
         Maximum output sequence length
+    d_model: int
+        Model dimension (must match the output dimension of the swipe point embedder)
     device: torch.device | str | None
         Device to create the model on (default: cuda if available, else cpu)
     weights_path: str | None
@@ -208,12 +208,12 @@ def get_model_from_configs(
 
     # Create all components via factories
     input_embedding = swipe_point_embedder_factory(input_embedding_config, device)
-    encoder = encoder_factory(encoder_config, D_MODEL_V1, device)
-    decoder = decoder_factory(decoder_config, D_MODEL_V1, device)
+    encoder = encoder_factory(encoder_config, d_model, device)
+    decoder = decoder_factory(decoder_config, d_model, device)
     word_char_embedding_model = get_word_char_embedder__vn1(
-        D_MODEL_V1, n_word_tokens, max_out_seq_len=max_out_seq_len,
+        d_model, n_word_tokens, max_out_seq_len=max_out_seq_len,
         dropout=0.1, device=device)
-    output_proj = nn.Linear(D_MODEL_V1, n_classes, device=device)
+    output_proj = nn.Linear(d_model, n_classes, device=device)
 
     # Assemble model
     model = EncoderDecoderTransformerLike(

--- a/src/modules/decoder_factory.py
+++ b/src/modules/decoder_factory.py
@@ -1,0 +1,128 @@
+"""
+Decoder factory for creating different decoder types.
+
+Supported decoder types:
+- "transformer_v1": Standard nn.TransformerDecoder (matches original implementation)
+"""
+
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _create_transformer_v1_decoder(
+    d_model: int,
+    params: dict,
+    device: Optional[Union[str, torch.device]] = None
+) -> nn.TransformerDecoder:
+    """
+    Creates a standard Transformer decoder matching the original v1 implementation.
+
+    Arguments:
+    ----------
+    d_model: int
+        Model dimension
+    params: dict
+        Dictionary with decoder parameters:
+        - num_layers: Number of decoder layers (default: 4)
+        - num_heads: Number of attention heads (default: 4)
+        - dim_feedforward: Feed-forward network dimension (default: 128)
+        - dropout: Dropout probability (default: 0.1)
+    device: Optional[Union[str, torch.device]]
+        Device to create the decoder on
+
+    Returns:
+    --------
+    decoder: nn.TransformerDecoder
+        Standard Transformer decoder instance
+    """
+    DEFAULT_NUM_LAYERS = 4
+    DEFAULT_NUM_HEADS = 4
+    DEFAULT_DIM_FEEDFORWARD = 128
+    DEFAULT_DROPOUT = 0.1
+
+    num_decoder_layers = params.get("num_layers", DEFAULT_NUM_LAYERS)
+    num_heads_decoder = params.get("num_heads", DEFAULT_NUM_HEADS)
+    dim_feedforward = params.get("dim_feedforward", DEFAULT_DIM_FEEDFORWARD)
+    dropout = params.get("dropout", DEFAULT_DROPOUT)
+    activation = F.relu
+
+    decoder_norm = nn.LayerNorm(d_model, eps=1e-5, bias=True)
+
+    decoder_layer = nn.TransformerDecoderLayer(
+        d_model=d_model,
+        nhead=num_heads_decoder,
+        dim_feedforward=dim_feedforward,
+        dropout=dropout,
+        activation=activation,
+    )
+
+    decoder = nn.TransformerDecoder(
+        decoder_layer,
+        num_layers=num_decoder_layers,
+        norm=decoder_norm,
+    )
+
+    if device is not None:
+        decoder = decoder.to(device)
+
+    return decoder
+
+
+def decoder_factory(
+    config: dict,
+    d_model: int,
+    device: Optional[Union[str, torch.device]] = None
+) -> nn.Module:
+    """
+    Creates a decoder from configuration.
+
+    Config structure:
+    {
+        "type": "transformer_v1",
+        "params": {
+            // type-specific parameters (optional, defaults will be used)
+        }
+    }
+
+    Arguments:
+    ----------
+    config: dict
+        Decoder configuration dictionary with keys:
+        - type: str, decoder type ("transformer_v1")
+        - params: dict, type-specific parameters (optional)
+    d_model: int
+        Model dimension
+    device: Optional[Union[str, torch.device]]
+        Device to create the decoder on
+
+    Returns:
+    --------
+    decoder: nn.Module
+        Decoder module compatible with our interface
+
+    Raises:
+    ------
+    ValueError
+        If decoder type is unknown
+    TypeError
+        If config is not a dictionary
+    """
+    if not isinstance(config, dict):
+        raise TypeError(f"decoder config must be a dict, got {type(config)}")
+
+    if "type" not in config:
+        raise ValueError("decoder config must have 'type' key")
+
+    decoder_type = config["type"]
+    params = config.get("params", {})
+
+    if decoder_type == "transformer_v1":
+        return _create_transformer_v1_decoder(d_model, params, device)
+    else:
+        raise ValueError(
+            f"Unknown decoder type: {decoder_type}. "
+            f"Supported types: 'transformer_v1'"
+        )

--- a/src/modules/encoder_factory.py
+++ b/src/modules/encoder_factory.py
@@ -1,0 +1,254 @@
+"""
+Encoder factory for creating different encoder types.
+
+Supported encoder types:
+- "transformer_v1": Standard nn.TransformerEncoder (default, matches original implementation)
+- "conformer": torchaudio.models.Conformer with adapter for interface compatibility
+"""
+
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ConformerEncoderAdapter(nn.Module):
+    """
+    Adapter to make torchaudio.models.Conformer compatible with our encoder interface.
+
+    Our interface: encoder(x, src_key_padding_mask) -> encoded
+    - x shape: (T, B, D) where T=seq_len, B=batch, D=d_model
+    - src_key_padding_mask: (B, T) boolean tensor (True means padded position)
+
+    Conformer interface: conformer(input, lengths) -> (output, output_lengths)
+    - input shape: (B, T, D)
+    - lengths: (B,) integer tensor (number of valid frames per batch element)
+    - Returns: (output_frames, output_lengths)
+    """
+
+    def __init__(self, conformer: nn.Module):
+        super().__init__()
+        self.conformer = conformer
+
+    def forward(self, x: torch.Tensor, src_key_padding_mask: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass that adapts our interface to Conformer's interface.
+
+        Arguments:
+        ----------
+        x: torch.Tensor
+            Input tensor with shape (T, B, D)
+        src_key_padding_mask: torch.Tensor
+            Boolean mask with shape (B, T), True means pad
+
+        Returns:
+        --------
+        encoded: torch.Tensor
+            Encoded tensor with shape (T, B, D)
+        """
+        # Transpose: (T, B, D) -> (B, T, D)
+        x = x.transpose(0, 1)
+
+        # Convert boolean padding mask to integer lengths
+        # src_key_padding_mask: (B, T) where True means padded
+        # We need lengths: (B,) number of valid (non-padded) frames
+        # ~src_key_padding_mask gives us True for valid positions
+        # .sum(dim=1) counts valid positions for each batch element
+        lengths = (~src_key_padding_mask).sum(dim=1).long()
+
+        # Call conformer (returns (output, output_lengths))
+        output, _ = self.conformer(x, lengths)
+
+        # Transpose back: (B, T, D) -> (T, B, D)
+        return output.transpose(0, 1)
+
+
+def _create_transformer_v1_encoder(
+    d_model: int,
+    params: dict,
+    device: Optional[Union[str, torch.device]] = None
+) -> nn.TransformerEncoder:
+    """
+    Creates a standard Transformer encoder matching the original v1 implementation.
+
+    Arguments:
+    ----------
+    d_model: int
+        Model dimension
+    params: dict
+        Dictionary with encoder parameters:
+        - num_layers: Number of encoder layers (default: 4)
+        - num_heads: Number of attention heads (default: 4)
+        - dim_feedforward: Feed-forward network dimension (default: 128)
+        - dropout: Dropout probability (default: 0.1)
+    device: Optional[Union[str, torch.device]]
+        Device to create the encoder on
+
+    Returns:
+    --------
+    encoder: nn.TransformerEncoder
+        Standard Transformer encoder instance
+    """
+    DEFAULT_NUM_LAYERS = 4
+    DEFAULT_NUM_HEADS = 4
+    DEFAULT_DIM_FEEDFORWARD = 128
+    DEFAULT_DROPOUT = 0.1
+
+    num_encoder_layers = params.get("num_layers", DEFAULT_NUM_LAYERS)
+    num_heads_encoder = params.get("num_heads", DEFAULT_NUM_HEADS)
+    dim_feedforward = params.get("dim_feedforward", DEFAULT_DIM_FEEDFORWARD)
+    dropout = params.get("dropout", DEFAULT_DROPOUT)
+    activation = F.relu
+
+    encoder_norm = nn.LayerNorm(d_model, eps=1e-5, bias=True)
+
+    encoder_layer = nn.TransformerEncoderLayer(
+        d_model=d_model,
+        nhead=num_heads_encoder,
+        dim_feedforward=dim_feedforward,
+        dropout=dropout,
+        activation=activation,
+    )
+
+    encoder = nn.TransformerEncoder(
+        encoder_layer,
+        num_layers=num_encoder_layers,
+        norm=encoder_norm,
+    )
+
+    if device is not None:
+        encoder = encoder.to(device)
+
+    return encoder
+
+
+def _create_conformer_encoder(
+    d_model: int,
+    params: dict,
+    device: Optional[Union[str, torch.device]] = None
+) -> nn.Module:
+    """
+    Creates a Conformer encoder with adapter for interface compatibility.
+
+    Arguments:
+    ----------
+    d_model: int
+        Model dimension (input_dim for Conformer)
+    params: dict
+        Dictionary with encoder parameters:
+        - num_heads: Number of attention heads (default: 4)
+        - ffn_dim: Feed-forward network dimension (default: 128)
+        - num_layers: Number of Conformer layers (default: 4)
+        - depthwise_conv_kernel_size: Kernel size for depthwise convolution (default: 31)
+        - dropout: Dropout probability (default: 0.0)
+        - use_group_norm: Use GroupNorm instead of BatchNorm (default: False)
+        - convolution_first: Apply convolution before attention (default: False)
+    device: Optional[Union[str, torch.device]]
+        Device to create the encoder on
+
+    Returns:
+    --------
+    encoder: nn.Module
+        ConformerEncoderAdapter wrapping torchaudio.models.Conformer
+    """
+    DEFAULT_NUM_HEADS = 4
+    DEFAULT_FFN_DIM = 128
+    DEFAULT_NUM_LAYERS = 4
+    DEFAULT_DEPTHWISE_CONV_KERNEL_SIZE = 31
+    DEFAULT_DROPOUT = 0.0
+    DEFAULT_USE_GROUP_NORM = False
+    DEFAULT_CONVOLUTION_FIRST = False
+
+    try:
+        import torchaudio.models as ta_models
+    except ImportError:
+        raise ImportError(
+            "torchaudio is required for Conformer encoder. "
+            "Install it with: pip install torchaudio"
+        )
+
+    num_heads = params.get("num_heads", DEFAULT_NUM_HEADS)
+    ffn_dim = params.get("ffn_dim", DEFAULT_FFN_DIM)
+    num_layers = params.get("num_layers", DEFAULT_NUM_LAYERS)
+    depthwise_conv_kernel_size = params.get("depthwise_conv_kernel_size", DEFAULT_DEPTHWISE_CONV_KERNEL_SIZE)
+    dropout = params.get("dropout", DEFAULT_DROPOUT)
+    use_group_norm = params.get("use_group_norm", DEFAULT_USE_GROUP_NORM)
+    convolution_first = params.get("convolution_first", DEFAULT_CONVOLUTION_FIRST)
+
+    conformer = ta_models.Conformer(
+        input_dim=d_model,
+        num_heads=num_heads,
+        ffn_dim=ffn_dim,
+        num_layers=num_layers,
+        depthwise_conv_kernel_size=depthwise_conv_kernel_size,
+        dropout=dropout,
+        use_group_norm=use_group_norm,
+        convolution_first=convolution_first,
+    )
+
+    if device is not None:
+        conformer = conformer.to(device)
+
+    # Wrap in adapter to match our encoder interface
+    return ConformerEncoderAdapter(conformer)
+
+
+def encoder_factory(
+    config: dict,
+    d_model: int,
+    device: Optional[Union[str, torch.device]] = None
+) -> nn.Module:
+    """
+    Creates an encoder from configuration.
+
+    Config structure:
+    {
+        "type": "transformer_v1" | "conformer",
+        "params": {
+            // type-specific parameters (optional, defaults will be used)
+        }
+    }
+
+    Arguments:
+    ----------
+    config: dict
+        Encoder configuration dictionary with keys:
+        - type: str, encoder type ("transformer_v1", "conformer", etc.)
+        - params: dict, type-specific parameters (optional)
+    d_model: int
+        Model dimension
+    device: Optional[Union[str, torch.device]]
+        Device to create the encoder on
+
+    Returns:
+    --------
+    encoder: nn.Module
+        Encoder module compatible with our interface:
+        encoder(x, src_key_padding_mask) -> encoded
+
+    Raises:
+    -------
+    ValueError
+        If encoder type is unknown
+    TypeError
+        If config is not a dictionary
+    """
+    if not isinstance(config, dict):
+        raise TypeError(f"encoder config must be a dict, got {type(config)}")
+
+    if "type" not in config:
+        raise ValueError("encoder config must have 'type' key")
+
+    encoder_type = config["type"]
+    params = config.get("params", {})
+
+    if encoder_type == "transformer_v1":
+        return _create_transformer_v1_encoder(d_model, params, device)
+    elif encoder_type == "conformer":
+        return _create_conformer_encoder(d_model, params, device)
+    else:
+        raise ValueError(
+            f"Unknown encoder type: {encoder_type}. "
+            f"Supported types: 'transformer_v1', 'conformer'"
+        )

--- a/src/plot_tb_metrics.py
+++ b/src/plot_tb_metrics.py
@@ -43,9 +43,8 @@ def parse_args() -> argparse.Namespace:
 def load_colors(colors_path: Optional[str]) -> dict[str, str]:
     if not colors_path:
         return {}
-    try:
-        with open(colors_path, "r", encoding="utf-8") as f:
-            return json.load(f)
+    with open(colors_path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def get_version_dirs(experiment_dir: Path) -> list[Path]:

--- a/src/predict.py
+++ b/src/predict.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from dataset import SwipeDataset, SwipeDatasetSubset
 from feature_extraction.swipe_feature_extractor_factory import swipe_feature_extractor_factory
 from logit_processors import VocabularyLogitProcessor
-from model import get_transformer__from_spe_config__vn1
+from model import get_model_from_configs
 from ns_tokenizers import CharLevelTokenizerv2, KeyboardTokenizer
 from word_generators import generator_factory
 
@@ -85,9 +85,16 @@ def predict(config: dict, num_workers: int):
         use_serialized_list=False
     )
     dataset_subset = SwipeDatasetSubset(dataset, config['grid_name'])
-    
-    model = get_transformer__from_spe_config__vn1(
-        spe_config=read_json(config['swipe_point_embedder_config_path']),
+
+    # Load all component configs
+    input_embedding_config = read_json(config['swipe_point_embedder_config_path'])
+    encoder_config = read_json(config['encoder_config_path'])
+    decoder_config = read_json(config['decoder_config_path'])
+
+    model = get_model_from_configs(
+        input_embedding_config=input_embedding_config,
+        encoder_config=encoder_config,
+        decoder_config=decoder_config,
         n_classes=config['num_classes'],
         n_word_tokens=len(subword_tokenizer.char_to_idx),
         max_out_seq_len=config['max_out_seq_len'],

--- a/src/predict.py
+++ b/src/predict.py
@@ -13,9 +13,11 @@ from tqdm import tqdm
 
 from dataset import SwipeDataset, SwipeDatasetSubset
 from feature_extraction.swipe_feature_extractor_factory import swipe_feature_extractor_factory
+from feature_extraction.swipe_feature_extractors import MultiFeatureExtractor, TrajectoryFeatureExtractor
 from logit_processors import VocabularyLogitProcessor
 from model import get_model_from_configs
 from ns_tokenizers import CharLevelTokenizerv2, KeyboardTokenizer
+from train import get_n_traj_feats, validate_d_model
 from word_generators import generator_factory
 
 
@@ -91,6 +93,15 @@ def predict(config: dict, num_workers: int):
     encoder_config = read_json(config['encoder_config_path'])
     decoder_config = read_json(config['decoder_config_path'])
 
+    # Validate d_model
+    d_model = config.get('d_model')
+    if d_model is None:
+        raise ValueError(
+            "d_model must be specified in prediction config. "
+            "It should match the output dimension of the swipe point embedder."
+        )
+    validate_d_model(d_model, feature_extractor, input_embedding_config)
+
     model = get_model_from_configs(
         input_embedding_config=input_embedding_config,
         encoder_config=encoder_config,
@@ -98,6 +109,7 @@ def predict(config: dict, num_workers: int):
         n_classes=config['num_classes'],
         n_word_tokens=len(subword_tokenizer.char_to_idx),
         max_out_seq_len=config['max_out_seq_len'],
+        d_model=d_model,
         device=device,
         weights_path=config['model_weights_path']
     )

--- a/src/train.py
+++ b/src/train.py
@@ -21,7 +21,7 @@ from feature_extraction.swipe_feature_extractors import MultiFeatureExtractor, T
 from pl_module import LitNeuroswipeModel
 from train_utils import CrossEntropyLossWithReshape
 from train_utils import EmptyCudaCacheCallback
-from model import get_transformer__from_spe_config__vn1
+from model import get_model_from_configs
 from utils.get_git_commit_hash import get_git_commit_hash
 
 
@@ -304,10 +304,16 @@ def main(train_config: dict) -> None:
         no_decay_keys=train_config["optimizer"].get("no_decay_keys", None)
     )
 
-    spe_config = read_json(train_config["swipe_point_embedder_config_path"])
-    model = get_transformer__from_spe_config__vn1(
-        spe_config=spe_config,
-        n_classes= train_config["num_classes"],
+    # Load all component configs
+    input_embedding_config = read_json(train_config["swipe_point_embedder_config_path"])
+    encoder_config = read_json(train_config["encoder_config_path"])
+    decoder_config = read_json(train_config["decoder_config_path"])
+
+    model = get_model_from_configs(
+        input_embedding_config=input_embedding_config,
+        encoder_config=encoder_config,
+        decoder_config=decoder_config,
+        n_classes=train_config["num_classes"],
         n_word_tokens=len(word_tokenizer.char_to_idx),
         max_out_seq_len=train_config["max_out_seq_len"],
         device=train_config["device"]


### PR DESCRIPTION
Model architecture and hyperparameters are now configurable via JSON configs instead of hardcoded.

Changes:
* Added encoder/decoder factory functions with config-based model creation
* New configs: configs/encoder/*.json, configs/decoder/*.json (transformer_v1, conformer)
* d_model is now a top-level config key with validation
* Removed model_name from configs → auto-generated from component basenames
* Added support for loading .ckpt checkpoint files when loading model state
